### PR TITLE
fix: tests waiting for artemis

### DIFF
--- a/.github/workflows/develop_build_and_test_linux.yml
+++ b/.github/workflows/develop_build_and_test_linux.yml
@@ -60,9 +60,7 @@ jobs:
       - name: Get dependencies
         run: go mod download
       - name: Build
-        run: go build -v -tags artemis -ldflags="-X
-          'github.com/makibytes/xmc/cmd.version=${{ github.ref_name }}'" -o amc
-          .
+        run: go build -v -tags artemis -ldflags="-X 'github.com/makibytes/xmc/cmd.version=${{ github.ref_name }}'" -o amc .
       - name: Run tests
         run: go test -short ./...
 
@@ -81,8 +79,6 @@ jobs:
       - name: Get dependencies
         run: go mod download
       - name: Build
-        run: go build -v -tags artemis -ldflags="-X
-          'github.com/makibytes/xmc/cmd.version=${{ github.ref_name }}'" -o
-          amc.exe .
+        run: go build -v -tags artemis -ldflags="-X 'github.com/makibytes/xmc/cmd.version=${{ github.ref_name }}'" -o amc.exe .
       - name: Run unit tests
         run: go test -short ./...

--- a/.github/workflows/develop_build_and_test_linux.yml
+++ b/.github/workflows/develop_build_and_test_linux.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+  workflow_dispatch:
 
 jobs:
   linux-amd64:

--- a/.github/workflows/develop_build_and_test_linux.yml
+++ b/.github/workflows/develop_build_and_test_linux.yml
@@ -15,57 +15,73 @@ jobs:
         ports:
           - 5672:5672
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.26.0
-    - name: Check out code
-      uses: actions/checkout@v5
-      with:
-        submodules: recursive
-    - name: Get dependencies
-      run: go mod download
-    - name: Build
-      run: go build -v -tags artemis -o amc .
-    - name: Run unit tests
-      run: go test -short ./...
-    - name: Run integration tests
-      run: ./run-tests.sh
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.26.0
+      - name: Check out code
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      - name: Get dependencies
+        run: go mod download
+      - name: Build
+        run: go build -v -tags artemis -o amc .
+      - name: Run unit tests
+        run: go test -short ./...
+      - name: Wait for Artemis
+        run: |
+          for attempt in {1..60}; do
+            if (echo > /dev/tcp/127.0.0.1/5672) >/dev/null 2>&1; then
+              echo "Artemis is ready"
+              exit 0
+            fi
+            echo "Waiting for Artemis on localhost:5672..."
+            sleep 2
+          done
+          echo "Artemis did not become ready in time" >&2
+          exit 1
+      - name: Run integration tests
+        run: ./run-tests.sh
 
   macos-amd64:
     name: Build macos/amd64
     runs-on: macos-26
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.26.0
-    - name: Check out code
-      uses: actions/checkout@v5
-      with:
-        submodules: recursive
-    - name: Get dependencies
-      run: go mod download
-    - name: Build
-      run: go build -v -tags artemis -ldflags="-X 'github.com/makibytes/xmc/cmd.version=${{ github.ref_name }}'" -o amc .
-    - name: Run tests
-      run: go test -short ./...
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.26.0
+      - name: Check out code
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      - name: Get dependencies
+        run: go mod download
+      - name: Build
+        run: go build -v -tags artemis -ldflags="-X
+          'github.com/makibytes/xmc/cmd.version=${{ github.ref_name }}'" -o amc
+          .
+      - name: Run tests
+        run: go test -short ./...
 
   windows-amd64:
     name: Build windows/amd64
     runs-on: windows-latest
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.26.0
-    - name: Check out code
-      uses: actions/checkout@v5
-      with:
-        submodules: recursive
-    - name: Get dependencies
-      run: go mod download
-    - name: Build
-      run: go build -v -tags artemis -ldflags="-X 'github.com/makibytes/xmc/cmd.version=${{ github.ref_name }}'" -o amc.exe .
-    - name: Run unit tests
-      run: go test -short ./...
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.26.0
+      - name: Check out code
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      - name: Get dependencies
+        run: go mod download
+      - name: Build
+        run: go build -v -tags artemis -ldflags="-X
+          'github.com/makibytes/xmc/cmd.version=${{ github.ref_name }}'" -o
+          amc.exe .
+      - name: Run unit tests
+        run: go test -short ./...

--- a/.github/workflows/main_build_and_test_linux.yml
+++ b/.github/workflows/main_build_and_test_linux.yml
@@ -17,21 +17,35 @@ jobs:
         ports:
           - 5672:5672
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.26.0
-    - name: Check out code
-      uses: actions/checkout@v5
-      with:
-        submodules: recursive
-    - name: Get dependencies
-      run: go mod download
-    - name: Build
-      run: go build -v -tags artemis -ldflags="-X 'github.com/makibytes/xmc/cmd.version=${{ github.ref_name }}'" -o amc .
-    - name: Run unit tests
-      run: go test -short ./...
-    - name: Setup bats and bats libs
-      uses: bats-core/bats-action@3.0.1
-    - name: Run integration tests
-      run: ./run-tests.sh
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.26.0
+      - name: Check out code
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+      - name: Get dependencies
+        run: go mod download
+      - name: Build
+        run: go build -v -tags artemis -ldflags="-X
+          'github.com/makibytes/xmc/cmd.version=${{ github.ref_name }}'" -o amc
+          .
+      - name: Run unit tests
+        run: go test -short ./...
+      - name: Setup bats and bats libs
+        uses: bats-core/bats-action@3.0.1
+      - name: Wait for Artemis
+        run: |
+          for attempt in {1..60}; do
+            if (echo > /dev/tcp/127.0.0.1/5672) >/dev/null 2>&1; then
+              echo "Artemis is ready"
+              exit 0
+            fi
+            echo "Waiting for Artemis on localhost:5672..."
+            sleep 2
+          done
+          echo "Artemis did not become ready in time" >&2
+          exit 1
+      - name: Run integration tests
+        run: ./run-tests.sh

--- a/.github/workflows/main_build_and_test_linux.yml
+++ b/.github/workflows/main_build_and_test_linux.yml
@@ -28,9 +28,7 @@ jobs:
       - name: Get dependencies
         run: go mod download
       - name: Build
-        run: go build -v -tags artemis -ldflags="-X
-          'github.com/makibytes/xmc/cmd.version=${{ github.ref_name }}'" -o amc
-          .
+        run: go build -v -tags artemis -ldflags="-X 'github.com/makibytes/xmc/cmd.version=${{ github.ref_name }}'" -o amc .
       - name: Run unit tests
         run: go test -short ./...
       - name: Setup bats and bats libs


### PR DESCRIPTION
The Linux workflows start an Artemis service container and immediately run integration tests, but there’s no readiness gate before the first connection attempt so the tests fail.

Also added the workflow_dispatch to develop workflow to be able to test this action manually on feature branches in the future.